### PR TITLE
telegraf: temporary fixing the version to 1.9.2

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,8 @@
 ---
 
+# temporary fixing the version
+telegraf_agent_version: 1.9.2
+
 telegraf_aws_checks: false
 telegraf_extra_checks: false
 


### PR DESCRIPTION
Every new version of telegraf, the old version fixed by
dj-wasabi/ansible-telegraf becomes unavailable which broke our builds.

```
    amazon-ebs: TASK [dj-wasabi.telegraf : Debian | Install telegraf package] ******************
    amazon-ebs: fatal: [127.0.0.1]: FAILED! => {"cache_update_time": 1547022836, "cache_updated": false, "changed": false, "msg": "'/usr/bin/apt-get -y -o \"Dpkg::Options::=--force-confdef\" -o \"Dpkg::Options::=--force-confold\"  --force-yes   install 'telegraf=1.9.1-1'' failed: E: Version '1.9.1-1' for 'telegraf' was not found
", "rc": 100, "stderr": "E: Version '1.9.1-1' for 'telegraf' was not found
", "stderr_lines": ["E: Version '1.9.1-1' for 'telegraf' was not found"], "stdout": "Reading package lists...
Building dependency tree...
Reading state information...
", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information..."]}
```

Upstream PR: https://github.com/dj-wasabi/ansible-telegraf/pull/80