### PR TITLE
telegraf: fix telegraf version override

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 # temporary fixing the version
-telegraf_agent_version: 1.9.2
+cycloid_telegraf_agent_version: 1.9.2
 
 telegraf_aws_checks: false
 telegraf_extra_checks: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,7 @@
     telegraf_agent_interval: "{{ cycloid_telegraf_agent_interval }}"
     telegraf_agent_flush_interval: "{{ cycloid_telegraf_agent_flush_interval }}"
     telegraf_plugins_default: "{{ cycloid_telegraf_plugins_default }}"
+    telegraf_agent_version: "{{cycloid_telegraf_agent_version}}"
 
 - include: extra_checks.yml
   when: telegraf_extra_checks


### PR DESCRIPTION
Wrongly assumed changing the original version variable would worked.

https://github.com/cycloidio/ansible-telegraf/pull/2