### PR TITLE
telegraf: temporary fixing the version to 1.9.3

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 # temporary fixing the version
-cycloid_telegraf_agent_version: 1.9.2
+cycloid_telegraf_agent_version: 1.9.3
 
 telegraf_aws_checks: false
 telegraf_extra_checks: false


### PR DESCRIPTION
Every new version of telegraf, the old version fixed by
dj-wasabi/ansible-telegraf becomes unavailable which broke our builds.

https://github.com/dj-wasabi/ansible-telegraf/pull/87