### PR TITLE
Temporarily setting telegraf_agent_package_state to `present`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@
 cycloid_telegraf_agent_version: 1.12.0
 
 # When set to latest, telegraf_agent_version will be ignored. (if you want a fixed version, use present)
-cycloid_telegraf_agent_package_state: latest
+cycloid_telegraf_agent_package_state: present
 
 telegraf_aws_checks: false
 telegraf_extra_checks: false


### PR DESCRIPTION
Reason: bad PR in upstream repository
https://github.com/dj-wasabi/ansible-telegraf/pull/108