### PR TITLE
chore(update): deprecated module in tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
-
 - include_role:
     name: dj-wasabi.telegraf
   vars:
@@ -12,8 +11,8 @@
     telegraf_agent_version: "{{cycloid_telegraf_agent_version}}"
     telegraf_agent_package_state: "{{ cycloid_telegraf_agent_package_state }}"
 
-- include: extra_checks.yml
+- include_tasks: extra_checks.yml
   when: telegraf_extra_checks
 
-- include: aws_checks.yml
+- include_tasks: aws_checks.yml
   when: telegraf_aws_checks


### PR DESCRIPTION
`include` module has been deprecated in 2.16 and throws an error in recent ansible versions. 
This prevents running this role on up-to-date ansible versions (>2.16)

I updated the two tasks using `include` to use the `include_tasks` module instead, which should behave the same. 

I can write tests if needs be.