### PR TITLE
Fix deprecated plugin (io => diskio)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,7 +25,7 @@ cycloid_telegraf_plugins_default:
     config:
         - percpu = true
   - plugin: disk
-  - plugin: io
+  - plugin: diskio
   - plugin: mem
   - plugin: net
     config:


### PR DESCRIPTION
See [this commit on dj-wasabi's repo](https://github.com/dj-wasabi/ansible-telegraf/commit/4064c8b040b6850a9788254fbd8facea16e2f02c)

Telegraf won't start/restart if this plugin is present

```
2024-03-12T11:22:47Z I! Loading config: /etc/telegraf/telegraf.conf
2024-03-12T11:22:47Z E! DeprecationError: Plugin "inputs.io" deprecated since version 0.10.0 and removed: use 'inputs.diskio' instead
2024-03-12T11:22:47Z E! error loading config file /etc/telegraf/telegraf.conf: error parsing io, plugin deprecated
```


